### PR TITLE
グを設定できるのは、管理者ユーザー以上

### DIFF
--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+	Plugin Name: Tag Set Restriction
+	Plugin URI:
+	Plugin Description: A tag bill is restricted to an administrator.
+	Plugin Version: 1.0
+	Plugin Date: 2016-06-30
+	Plugin Author:38qa.net
+	Plugin Author URI:
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+	Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
+
+// language file
+qa_register_plugin_phrases('qa-tag-set-restriction-lang-*.php', 'qa_tag_set_restriction');
+// admin
+qa_register_plugin_module('module', 'qa-tag-set-restriction-admin.php', 'qa_tag_set_restriction_admin', 'Tag Set Restriction Admin');
+// layer
+qa_register_plugin_layer('qa-tag-set-restriction-layer.php', 'Tag Set Restriction Layer');

--- a/qa-tag-set-restriction-admin.php
+++ b/qa-tag-set-restriction-admin.php
@@ -1,0 +1,47 @@
+<?php
+
+class qa_tag_set_restriction_admin {
+
+	function option_default($option) {
+		switch($option) {
+			case 'q2a_tag_set_restriction_enabled':
+				return 0;
+			default:
+				return null;
+		}
+	}
+
+	function allow_template($template) {
+		return ($template != 'admin');
+	}
+
+	function admin_form(&$qa_content){
+		// process the admin form if admin hit Save-Changes-button
+		$ok = null;
+		if (qa_clicked('q2a_tag_set_restriction_save')) {
+			qa_opt('q2a_tag_set_restriction_enabled', (bool)qa_post_text('q2a_tag_set_restriction_enabled'));
+			$ok = qa_lang('admin/options_saved');
+		}
+
+		// form fields to display frontend for admin
+		$fields = array();
+
+		$fields[] = array(
+			'type' => 'checkbox',
+			'label' => qa_lang('qa_tag_set_restriction/enable_plugin'),
+			'tags' => 'NAME="q2a_tag_set_restriction_enabled"',
+			'value' => qa_opt('q2a_tag_set_restriction_enabled'),
+		);
+
+		return array(
+			'ok' => ($ok && !isset($error)) ? $ok : null,
+			'fields' => $fields,
+			'buttons' => array(
+				array(
+					'label' => qa_lang_html('main/save_button'),
+					'tags' => 'name="q2a_tag_set_restriction_save"',
+				),
+			),
+		);
+	}
+}

--- a/qa-tag-set-restriction-lang-default.php
+++ b/qa-tag-set-restriction-lang-default.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+	Plugin Name: Tag Set Restriction
+	Plugin URI:
+	Plugin Description: A tag bill is restricted to an administrator.
+	Plugin Version: 1.0
+	Plugin Date: 2016-06-30
+	Plugin Author:38qa.net
+	Plugin Author URI:
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+	Plugin Update Check URI:
+*/
+
+	return array(
+		// default
+		'enable_plugin' => 'Enable the Plugin',
+	);
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-tag-set-restriction-lang-ja.php
+++ b/qa-tag-set-restriction-lang-ja.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+	Plugin Name: Tag Set Restriction
+	Plugin URI:
+	Plugin Description: A tag bill is restricted to an administrator.
+	Plugin Version: 1.0
+	Plugin Date: 2016-06-30
+	Plugin Author:38qa.net
+	Plugin Author URI:
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+	Plugin Update Check URI:
+*/
+
+	return array(
+		// japanese
+		'enable_plugin' => 'プラグインを有効にする',
+	);
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-tag-set-restriction-layer.php
+++ b/qa-tag-set-restriction-layer.php
@@ -1,0 +1,17 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+
+	function main()
+	{
+		if ($this->template == 'ask') {
+			if (!qa_is_logged_in() || qa_get_logged_in_level() < QA_USER_LEVEL_SUPER) {
+				$this->content['form']['fields']['tags']['label'] = '';
+				$this->content['form']['fields']['tags']['tags'] .= ' style="display: none;"';
+			}
+		}
+		qa_html_theme_base::main();
+	}
+
+}

--- a/qa-tag-set-restriction-layer.php
+++ b/qa-tag-set-restriction-layer.php
@@ -6,7 +6,9 @@ class qa_html_theme_layer extends qa_html_theme_base
 	function main()
 	{
 		if ($this->template == 'ask') {
-			if (!qa_is_logged_in() || qa_get_logged_in_level() < QA_USER_LEVEL_SUPER) {
+			if (!qa_is_logged_in() ||
+				(qa_opt('q2a_tag_set_restriction_enabled') &&
+				 qa_get_logged_in_level() < QA_USER_LEVEL_SUPER)) {
 				$this->content['form']['fields']['tags']['label'] = '';
 				$this->content['form']['fields']['tags']['tags'] .= ' style="display: none;"';
 			}

--- a/qa-tag-set-restriction-layer.php
+++ b/qa-tag-set-restriction-layer.php
@@ -5,12 +5,19 @@ class qa_html_theme_layer extends qa_html_theme_base
 
 	function main()
 	{
-		if ($this->template == 'ask') {
-			if (!qa_is_logged_in() ||
-				(qa_opt('q2a_tag_set_restriction_enabled') &&
-				 qa_get_logged_in_level() < QA_USER_LEVEL_SUPER)) {
+		if ( !qa_is_logged_in() ||
+		 (qa_opt('q2a_tag_set_restriction_enabled') &&
+		 qa_get_logged_in_level() < QA_USER_LEVEL_SUPER) ) {
+			// 質問投稿ページ
+			if ($this->template == 'ask') {
 				$this->content['form']['fields']['tags']['label'] = '';
 				$this->content['form']['fields']['tags']['tags'] .= ' style="display: none;"';
+			}
+			// 質問編集ページ
+			if ($this->template == 'question' &&
+				strpos(qa_get_state(), 'edit') !== false) {
+				$this->content['form_q_edit']['fields']['tags']['label'] = '';
+				$this->content['form_q_edit']['fields']['tags']['tags'] .= ' style="display: none;"';
 			}
 		}
 		qa_html_theme_base::main();


### PR DESCRIPTION
- 管理者ユーザーのみタグフォーム表示
  - 質問投稿ページ
  - 質問編集ページ
- 管理画面のプラグイン設定で有効、無効を切り替えられる
- その他のタグ機能（タグで絞り込んだり）には影響しない
